### PR TITLE
Fixed chunked traffic error.

### DIFF
--- a/Simple_Http_Proxy/Proxy/HttpProxyListener.cs
+++ b/Simple_Http_Proxy/Proxy/HttpProxyListener.cs
@@ -180,7 +180,6 @@ namespace Simple_Http_Proxy.Proxy
             {
                 var webResponse = webRequest.EndGetResponse(result);
                 originalResponse.ContentType = webResponse.ContentType;
-                originalResponse.ContentLength64 = webResponse.ContentLength;
                 // copy over headers
                 foreach(string key in webResponse.Headers.AllKeys)
                 {

--- a/Simple_Http_Proxy/Utils/HeaderUtil.cs
+++ b/Simple_Http_Proxy/Utils/HeaderUtil.cs
@@ -26,6 +26,7 @@ namespace Simple_Http_Proxy.Utils
                 case "Content-Type":
                 case "Referrer":
                 case "User-Agent":
+                case "Keep-Alive":
                     isReserved = true;
                     break;
                 default:


### PR DESCRIPTION
Removed content-length copy from web request as that was causing some errors with chunked data.
Added the reserved header "Keep-Alive" as that was causing keep-alive requests to throw errors.
